### PR TITLE
fix uncorrect mtu config

### DIFF
--- a/virtio_vhostuser.c
+++ b/virtio_vhostuser.c
@@ -382,11 +382,15 @@ virtio_vhostuser_vring_state_change_cb(struct virtio_net *dev,
 }
 #endif
 
-#if RTE_VERSION >= RTE_VERSION_NUM(17,5,0,0)
+#if RTE_VERSION >= RTE_VERSION_NUM(21,11,0,0)
+static const struct rte_vhost_device_ops virtio_vhostuser_ops = {
+#elif RTE_VERSION >= RTE_VERSION_NUM(17,5,0,0)
 static const struct vhost_device_ops virtio_vhostuser_ops = {
-	.features_changed = virtio_vhostuser_features_changed_cb,
 #else
 static const struct virtio_net_device_ops virtio_vhostuser_ops = {
+#endif
+#if RTE_VERSION >= RTE_VERSION_NUM(17,5,0,0)
+	.features_changed = virtio_vhostuser_features_changed_cb,
 #endif
 	.new_device =  virtio_vhostuser_new_device_cb,
 	.destroy_device = virtio_vhostuser_destroy_device_cb,

--- a/virtio_worker.c
+++ b/virtio_worker.c
@@ -429,8 +429,8 @@ static int dev_queue_configure(const char *name, dpdk_port_t port_id,
 	eth_conf.rxmode.jumbo_frame = 1;
 	eth_conf.rxmode.hw_ip_checksum = 1;
 #endif
-	eth_conf.rxmode.max_rx_pkt_len = relay->use_jumbo ? JUMBO_MBUF_SIZE :
-						DEFAULT_MBUF_SIZE;
+	eth_conf.rxmode.max_rx_pkt_len = relay->use_jumbo ? JUMBO_IP_MTU :
+						DEFAULT_IP_MTU;
 	err = rte_eth_dev_configure(port_id, 1, 1, &eth_conf);
 	if (err != 0) {
 		log_error("rte_eth_dev_configure(%hhu, 1, 1) failed with error %i",


### PR DESCRIPTION
the old config caused an "net_mlx5: port 0 Rx queue 0: Scatter offload is not configured and no enough mbuf space(2282) to contain the maximum RX packet length(2282) with head-room(128)" error in our mellanox nics environment.